### PR TITLE
Fix container error when api_key is not configured

### DIFF
--- a/DependencyInjection/OhGoogleMapFormTypeExtension.php
+++ b/DependencyInjection/OhGoogleMapFormTypeExtension.php
@@ -26,9 +26,10 @@ class OhGoogleMapFormTypeExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        $container
-            ->getDefinition('form.type.oh_google_maps')
-            ->addArgument($config['api_key']);
-
+        if (!empty($config['api_key'])) {
+            $container
+                ->getDefinition('form.type.oh_google_maps')
+                ->addArgument($config['api_key']);
+        }
     }
 }


### PR DESCRIPTION
When I executed `composer require krixer/google-map-form-type-bundle` I got the following message:

> Configuring krixer/google-map-form-type-bundle (>=v1.2): From auto-generated recipe
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In OhGoogleMapFormTypeExtension.php line 31:
!!                                      
!!    Notice: Undefined index: api_key  
!!                                      
!!
!!
Script @auto-scripts was called via post-update-cmd
> 
> Installation failed, reverting ./composer.json to its original content.

This PR fixes that bug.