### PR TITLE
Fix javascript error when addr_field is disabled

### DIFF
--- a/Resources/views/Form/google_maps.html.twig
+++ b/Resources/views/Form/google_maps.html.twig
@@ -61,13 +61,9 @@
 				  'lng_field'          : $('#{{ attribute(form, lng_name).vars.id }}'),
 				{% if addr_name is defined and addr_name and attribute(form, addr_name) %}
 				  'addr_field'         : $('#{{ attribute(form, addr_name).vars.id }}'),
-				{% else %}
-				  'addr_field'         :  {},
 				{% endif %}
 				{% if addr_use_btn is defined and addr_use_btn and attribute(form, addr_use_btn.name) %}
 				  'addr_use_btn'       : $('#{{ attribute(form, addr_use_btn.name).vars.id }}'),
-				{% else %}
-                  'addr_use_btn'       : {},
 				{% endif %}
 				  'callback'           : oh_google_maps_callback
 				});


### PR DESCRIPTION
`setAddress()` in jquery.ohgooglemaps.js expects `addr_field` to be empty when the option is not present.