### PR TITLE
Use lat_name and lng_name instead of fixed names

### DIFF
--- a/Resources/views/Form/google_maps.html.twig
+++ b/Resources/views/Form/google_maps.html.twig
@@ -56,7 +56,7 @@
 				  'current_position_el': $('#{{ id }}_current_position'),
 				  'default_lat'        : '{% if value is defined and value and attribute(value, lat_name) %}{{ attribute(value, lat_name) }}{% else %}{{ default_lat }}{% endif %}',
 				  'default_lng'        : '{% if value is defined and value and attribute(value, lng_name) %}{{ attribute(value, lng_name) }}{% else %}{{ default_lng }}{% endif %}',
-				  'default_zoom'       : {% if value is defined and value and value.latitude and value.longitude %}15{% else %}5{% endif %},
+				  'default_zoom'       : {% if value is defined and value and attribute(value, lng_name) %}{{ attribute(value, lng_name) }}15{% else %}5{% endif %},
 				  'lat_field'          : $('#{{ attribute(form, lat_name).vars.id }}'),
 				  'lng_field'          : $('#{{ attribute(form, lng_name).vars.id }}'),
 				{% if addr_name is defined and addr_name and attribute(form, addr_name) %}

--- a/Validator/Constraints/LatLngValidator.php
+++ b/Validator/Constraints/LatLngValidator.php
@@ -9,15 +9,18 @@ class LatLngValidator extends ConstraintValidator
 {
     public function validate($value, Constraint $constraint)
     {
-		if (!preg_match('/^[0-9\-\.]+$/', $value['latitude'], $matches) || !preg_match('/^[0-9\-\.]+$/', $value['longitude'], $matches)) {
-			 $this->context->addViolation($constraint->message, array('%latitude%' => (float)$value['latitude'], '%longitude%' => (float)$value['longitude']));
-			 return false;
-		}
-		if($value['latitude'] > 90 || $value['latitude'] < -90 || $value['longitude'] > 180 || $value['longitude'] < -180)
-		{
-			 $this->context->addViolation($constraint->message, array('%latitude%' => (float)$value['latitude'], '%longitude%' => (float)$value['longitude']));
-			 return false;
-		}
+        $latitude = isset($value['latitude']) ? $value['latitude'] : $value['lat'];
+        $longitude = isset($value['longitude']) ? $value['longitude'] : $value['lng'];
+
+        if (!preg_match('/^[0-9\-\.]+$/', $latitude, $matches) || !preg_match('/^[0-9\-\.]+$/', $longitude, $matches)) {
+            $this->context->addViolation($constraint->message, array('%latitude%' => (float)$latitude, '%longitude%' => (float)$longitude));
+            return false;
+        }
+        if($latitude > 90 || $latitude < -90 || $longitude > 180 || $longitude < -180)
+        {
+            $this->context->addViolation($constraint->message, array('%latitude%' => (float)$latitude, '%longitude%' => (float)$longitude));
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
Hi. I've fixed the hardcoded names to allow users to have the vars named differently.

Have you thought about releasing a version since the original repository doesn't seem to be maintained anymore?